### PR TITLE
Bumps @hono/mcp to 0.2.0

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@aws-lambda-powertools/logger": "^2.29.0",
-    "@hono/mcp": "^0.1.5",
+    "@hono/mcp": "^0.2.0",
     "@modelcontextprotocol/sdk": "^1.22.0",
     "hono": "^4.10.6",
     "zod": "^3.25.76"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: ^2.29.0
         version: 2.29.0
       '@hono/mcp':
-        specifier: ^0.1.5
-        version: 0.1.5(@modelcontextprotocol/sdk@1.22.0)(hono@4.10.6)
+        specifier: ^0.2.0
+        version: 0.2.0(@modelcontextprotocol/sdk@1.22.0)(hono-rate-limiter@0.4.2(hono@4.10.6))(hono@4.10.6)
       '@modelcontextprotocol/sdk':
         specifier: ^1.22.0
         version: 1.22.0
@@ -592,6 +592,13 @@ packages:
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.12.0
       hono: '>=4.0.0'
+
+  '@hono/mcp@0.2.0':
+    resolution: {integrity: sha512-kKZklY+yApZce6zzHzQPrEOhon4O7ANstUCDWstvGF3+B/Qn0j9mWUyps2XZhA/PzKoFGUBuAu1SwTFc7JRX9A==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.17.3
+      hono: '*'
+      hono-rate-limiter: ^0.4.2
 
   '@hono/node-server@1.19.6':
     resolution: {integrity: sha512-Shz/KjlIeAhfiuE93NDKVdZ7HdBVLQAfdbaXEaoAVO3ic9ibRSLGIQGkcBbFyuLr+7/1D5ZCINM8B+6IvXeMtw==}
@@ -1560,6 +1567,11 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hono-rate-limiter@0.4.2:
+    resolution: {integrity: sha512-AAtFqgADyrmbDijcRTT/HJfwqfvhalya2Zo+MgfdrMPas3zSMD8SU03cv+ZsYwRU1swv7zgVt0shwN059yzhjw==}
+    peerDependencies:
+      hono: ^4.1.1
 
   hono@4.10.6:
     resolution: {integrity: sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==}
@@ -2642,6 +2654,13 @@ snapshots:
     dependencies:
       '@modelcontextprotocol/sdk': 1.22.0
       hono: 4.10.6
+
+  '@hono/mcp@0.2.0(@modelcontextprotocol/sdk@1.22.0)(hono-rate-limiter@0.4.2(hono@4.10.6))(hono@4.10.6)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.22.0
+      hono: 4.10.6
+      hono-rate-limiter: 0.4.2(hono@4.10.6)
+      pkce-challenge: 5.0.1
 
   '@hono/node-server@1.19.6(hono@4.10.6)':
     dependencies:
@@ -3761,6 +3780,10 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hono-rate-limiter@0.4.2(hono@4.10.6):
+    dependencies:
+      hono: 4.10.6
 
   hono@4.10.6: {}
 


### PR DESCRIPTION
## 概要

@hono/mcp を 0.2.0 にアップデート。

## 変更点

| 追加・変更・削除したファイル (リポジトリルートからの相対パス) | 変更内容 | 事由 |
|-----------------------------------------------------|---------|-----|
| package/package.json | @hono/mcp を 0.2.0 にアップデート | 依存パッケージの最新化 |

## 確認事項

- [X] (Typescriptの場合) `pnpm audit --fix` で脆弱性を修正済みか？
- [X] (Typescriptの場合) `pnpm lint-fix` でコードスタイルは修正済みか？
- [X] (Markdownの場合)`markdownlint-2` で Markdown の lint は修正済みか？

## 特記事項

なし
